### PR TITLE
Fix email code retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 mongodb-data/
 mongodb-logs/
 node_modules/
+mongodb-linux-*.tgz

--- a/index.js
+++ b/index.js
@@ -1,9 +1,5 @@
 const express = require('express');
-const imaps = require('imap-simple');
 const cors = require('cors');
-const fs = require('fs');
-const axios = require('axios');
-const nodemailer = require('nodemailer');
 const path = require('path');
 const { MongoClient } = require('mongodb');
 const session = require('express-session');

--- a/init-database.js
+++ b/init-database.js
@@ -21,6 +21,7 @@ async function initializeDatabase() {
         await db.createCollection('admin_users');
         await db.createCollection('active_sessions');
         await db.createCollection('blocked_ips');
+        await db.createCollection('codes');
         await db.createCollection('settings');
 
         // Create indexes
@@ -47,6 +48,7 @@ async function initializeDatabase() {
             { address: 1 },
             { unique: true }
         );
+        await db.collection('codes').createIndex({ fetchedAt: 1 });
         await db.collection('settings').createIndex(
             { key: 1 },
             { unique: true }

--- a/rotas/auth.js
+++ b/rotas/auth.js
@@ -96,50 +96,6 @@ async function getIPInfo(ip) {
   }
 }
 
-      // extrai o número de 6 dígitos
-      const parsed = await simpleParser(body).catch(() => ({}));
-      const content = parsed.text || parsed.html || body;
-      const mCode = content.match(/(?:Your ChatGPT code is|=)\s*(\d{6})/);
-      if (!mCode) continue;
-
-      // extrai o e-mail do header
-      const headerText = msg.parts.find(p => p.which === 'HEADER').body;
-      let emailAddr = '';
-      let m = /X-X-Forwarded-For:\s*(.+)/i.exec(headerText);
-      if (m) {
-        for (const fwd of m[1].split(',')) {
-          const t = fwd.trim();
-          if (t.includes('@') && t !== 'aanniitaas@gmail.com') {
-            emailAddr = t;
-            break;
-          }
-        }
-      }
-      if (!emailAddr) {
-        m = /Delivered-To:\s*(.+)/i.exec(headerText);
-        if (m) emailAddr = m[1].trim();
-      }
-      if (!emailAddr) {
-        m = /To:\s*(.+)/i.exec(headerText);
-        if (m) emailAddr = m[1].replace(/.*<([^>]+)>.*/, '$1').trim();
-      }
-      emailAddr = emailAddr.replace(/\s*aanniitaas@gmail.com\s*/i, '').trim();
-
-      // só inclui se bater com o parâmetro `email` (ou se email === '')
-      if (!email || emailAddr.toLowerCase() === email.toLowerCase()) {
-        codes.push({ code: mCode[1], email: emailAddr || 'E-mail não encontrado' });
-        if (codes.length >= limit) break;
-      }
-    }
-
-    connection.end();
-    return codes;
-  } catch (err) {
-    console.error('Error fetching IMAP codes:', err);
-    return [];
-  }
-}
-
 
 // Check blocked IP middleware
 const checkBlockedIP = async (req, res, next) => {

--- a/utils/emailUtils.js
+++ b/utils/emailUtils.js
@@ -1,0 +1,116 @@
+const nodemailer = require('nodemailer');
+const imaps = require('imap-simple');
+const { simpleParser } = require('mailparser');
+
+async function getTransporter(db) {
+  const defaults = {
+    host: 'smtp.gmail.com',
+    port: 465,
+    secure: true,
+    user: 'contactgestorvip@gmail.com',
+    pass: 'aoqmdezazknbbpg'
+  };
+  const config = (await db.collection('settings').findOne({ key: 'emailConfig' })) || {};
+  const smtp = Object.assign({}, defaults, config.smtp);
+  return nodemailer.createTransport({
+    host: smtp.host,
+    port: smtp.port,
+    secure: !!smtp.secure,
+    auth: smtp.user ? { user: smtp.user, pass: smtp.pass } : undefined
+  });
+}
+
+async function fetchImapCodes(db, email, limit = 5) {
+  const defaults = {
+    host: 'imap.uhserver.com',
+    port: 993,
+    tls: true,
+    user: 'financeiro@clubevip.net',
+    pass: 'CYRSG6vT86ZVfe'
+  };
+  const config = (await db.collection('settings').findOne({ key: 'emailConfig' })) || {};
+  const imapCfg = Object.assign({}, defaults, config.imap);
+
+  const imapConfig = {
+    imap: {
+      user: imapCfg.user,
+      password: imapCfg.pass,
+      host: imapCfg.host,
+      port: imapCfg.port,
+      tls: !!imapCfg.tls,
+      tlsOptions: { rejectUnauthorized: false },
+      authTimeout: 10000,
+      connTimeout: 10000
+    }
+  };
+
+  try {
+    const connection = await imaps.connect(imapConfig);
+    await connection.openBox('INBOX');
+    const yesterday = new Date(Date.now() - 24 * 3600 * 1000);
+    const searchCriteria = [
+      ['FROM', 'noreply@tm.openai.com'],
+      ['SINCE', yesterday]
+    ];
+    const messages = await connection.search(searchCriteria, {
+      bodies: ['HEADER', 'TEXT'],
+      struct: true
+    });
+    messages.sort((a, b) => b.attributes.date - a.attributes.date);
+
+    const codes = [];
+    for (const msg of messages) {
+      let body = '';
+      const textPart = imaps.getParts(msg.attributes.struct).find(p => p.type === 'text' && !p.disposition);
+      if (textPart) {
+        body = await connection.getPartData(msg, textPart);
+      } else {
+        const text = msg.parts.find(p => p.which === 'TEXT');
+        body = text ? text.body : '';
+      }
+
+      const parsed = await simpleParser(body).catch(() => ({}));
+      const content = parsed.text || parsed.html || body;
+      const mCode = content.match(/(?:Your ChatGPT code is|=)\s*(\d{6})/);
+      if (!mCode) continue;
+
+      const header = msg.parts.find(p => p.which === 'HEADER');
+      const headerText = header ? header.body : '';
+      let emailAddr = '';
+      let m = /X-X-Forwarded-For:\s*(.+)/i.exec(headerText);
+      if (m) {
+        for (const fwd of m[1].split(',')) {
+          const t = fwd.trim();
+          if (t.includes('@') && t !== 'aanniitaas@gmail.com') {
+            emailAddr = t;
+            break;
+          }
+        }
+      }
+      if (!emailAddr) {
+        m = /Delivered-To:\s*(.+)/i.exec(headerText);
+        if (m) emailAddr = m[1].trim();
+      }
+      if (!emailAddr) {
+        m = /To:\s*(.+)/i.exec(headerText);
+        if (m) emailAddr = m[1].replace(/.*<([^>]+)>.*/, '$1').trim();
+      }
+      emailAddr = emailAddr.replace(/\s*aanniitaas@gmail.com\s*/i, '').trim();
+
+      if (!email || emailAddr.toLowerCase() === email.toLowerCase()) {
+        const record = { code: mCode[1], email: emailAddr || 'E-mail não encontrado', fetchedAt: new Date() };
+        codes.push(record);
+        await db.collection('codes').insertOne(record).catch(() => {});
+        if (codes.length >= limit) break;
+      }
+    }
+
+    connection.end();
+    return codes;
+  } catch (err) {
+    console.error('Error fetching IMAP codes:', err);
+    return [];
+  }
+}
+
+module.exports = { getTransporter, fetchImapCodes };

--- a/utils/emailUtils.js
+++ b/utils/emailUtils.js
@@ -72,8 +72,12 @@ async function fetchImapCodes(db, email, limit = 5) {
     }
   };
 
+  let connection;
   try {
-    const connection = await imaps.connect(imapConfig);
+    connection = await imaps.connect(imapConfig);
+    connection.on('error', err => {
+      console.error('IMAP connection error:', err);
+    });
     await connection.openBox(mailbox);
     const yesterday = new Date(Date.now() - 24 * 3600 * 1000);
     const searchCriteria = [
@@ -133,11 +137,16 @@ async function fetchImapCodes(db, email, limit = 5) {
       }
     }
 
-    connection.end();
     return codes;
   } catch (err) {
     console.error('Error fetching IMAP codes:', err);
     return [];
+  } finally {
+    if (connection) {
+      try {
+        connection.end();
+      } catch (_) {}
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- move email functions to `utils/emailUtils`
- fetch codes using new helper and store them in DB
- create `codes` collection and index during DB init
- ignore packaged MongoDB archive

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6855ac12da6883238750d112439fe53d