### PR TITLE
Add switch for email code verification and track top accesses

### DIFF
--- a/views/admin/dashboard.ejs
+++ b/views/admin/dashboard.ejs
@@ -79,6 +79,28 @@
 </div>
 
 <div class="table-container">
+    <h4 class="mb-3">Top Acessos</h4>
+    <div class="table-responsive">
+        <table class="table">
+            <thead>
+                <tr>
+                    <th>Email</th>
+                    <th>Logins</th>
+                </tr>
+            </thead>
+            <tbody>
+                <% topAccesses.forEach(a => { %>
+                <tr>
+                    <td><%= a._id %></td>
+                    <td><%= a.count %></td>
+                </tr>
+                <% }); %>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<div class="table-container">
     <h4 class="mb-3">Logs Recentes</h4>
     <div class="table-responsive">
         <table class="table">

--- a/views/admin/settings.ejs
+++ b/views/admin/settings.ejs
@@ -54,6 +54,20 @@
 
 <div class="card settings-card mt-4">
     <div class="card-body">
+        <h4 class="card-title mb-4">Verificação por Código</h4>
+        <form id="verificationFormSetting">
+            <div class="form-check form-switch mb-3">
+                <input class="form-check-input" type="checkbox" id="verificationEnabled" <%= verification.enabled ? 'checked' : '' %>>
+                <label class="form-check-label" for="verificationEnabled">Exigir Código de Verificação</label>
+            </div>
+            <button type="submit" class="btn btn-primary">Salvar</button>
+        </form>
+        <div id="verificationMessage" class="mt-3"></div>
+    </div>
+</div>
+
+<div class="card settings-card mt-4">
+    <div class="card-body">
         <h4 class="card-title mb-4">Branding</h4>
         <form id="brandingForm" enctype="multipart/form-data">
             <div class="mb-3">
@@ -165,6 +179,8 @@
         const reloadForm = document.getElementById('reloadSettingsForm');
         const reloadEnabled = document.getElementById('reloadEnabled');
         const reloadLimit = document.getElementById('reloadLimit');
+        const verificationForm = document.getElementById('verificationFormSetting');
+        const verificationEnabled = document.getElementById('verificationEnabled');
         const colorsForm = document.getElementById('colorsForm');
         const bgStart = document.getElementById('bgStart');
         const bgEnd = document.getElementById('bgEnd');
@@ -253,6 +269,25 @@
                 }
             } catch (err) {
                 showMessage('reloadSettingsMessage', 'Erro ao salvar', 'danger');
+            }
+        });
+
+        verificationForm.addEventListener('submit', async function(e) {
+            e.preventDefault();
+            const enabled = verificationEnabled.checked;
+            try {
+                const res = await fetch('/admin/settings/email-verification', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ enabled })
+                });
+                if (res.ok) {
+                    showMessage('verificationMessage', 'Configuração salva', 'success');
+                } else {
+                    showMessage('verificationMessage', 'Erro ao salvar', 'danger');
+                }
+            } catch (err) {
+                showMessage('verificationMessage', 'Erro ao salvar', 'danger');
             }
         });
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -11,6 +11,9 @@
         --text-color: <%= colors.textColor %>;
     }
 </style>
+<script>
+    const CODE_REQUIRED = <%- verificationRequired ? 'true' : 'false' %>;
+</script>
 <div class="container">
     <div class="row justify-content-center mt-5">
         <div class="col-md-6 col-lg-4">
@@ -34,8 +37,8 @@
                             </label>
                             <input type="email" class="form-control" id="email" required>
                         </div>
-                        <button type="button" class="btn btn-primary w-100" onclick="requestCode()">
-                            <i class="fas fa-paper-plane me-2"></i>Solicitar Código
+                        <button type="button" id="loginButton" class="btn btn-primary w-100" onclick="requestCode()">
+                            <i class="fas fa-paper-plane me-2"></i><span id="loginBtnLabel">Solicitar Código</span>
                         </button>
                     </div>
 
@@ -101,7 +104,13 @@
         }
     }
 
-    document.addEventListener('DOMContentLoaded', captureIPInfo);
+    document.addEventListener('DOMContentLoaded', function() {
+        captureIPInfo();
+        if(!CODE_REQUIRED) {
+            document.getElementById('verificationForm').style.display = 'none';
+            document.getElementById('loginBtnLabel').textContent = 'Entrar';
+        }
+    });
 
     async function requestCode() {
         const email = document.getElementById('email').value;
@@ -126,11 +135,15 @@
             });
 
             const data = await response.json();
-            
+
             if (response.ok) {
                 currentEmail = email;
-                document.getElementById('loginForm').style.display = 'none';
-                document.getElementById('verificationForm').style.display = 'block';
+                if (CODE_REQUIRED) {
+                    document.getElementById('loginForm').style.display = 'none';
+                    document.getElementById('verificationForm').style.display = 'block';
+                } else {
+                    window.location.href = '/codes';
+                }
             } else {
                 showError(data.error || 'Erro ao enviar código.');
             }


### PR DESCRIPTION
## Summary
- allow admins to toggle verification code requirement
- show top access count in dashboard
- update login flow to optionally skip verification code
- update admin settings UI for new option

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685622d4704083239719cbafb5470969