### PR TITLE
Improve code ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ chatgpt-codes-system/
 - ✅ Autenticação por email com código de verificação
 - ✅ Sistema de sessões
 - ✅ Gerenciamento de códigos do ChatGPT
+- ✅ Códigos listados pelo horário de recebimento do email
 - ✅ Interface web responsiva
 - ✅ Logs de acesso
 - ✅ MongoDB local automático (sem instalação manual!)

--- a/rotas/auth.js
+++ b/rotas/auth.js
@@ -526,16 +526,17 @@ router.get('/codes', async (req, res) => {
     const codes = await db
       .collection('codes')
       .aggregate([
-        { $sort: { fetchedAt: -1 } },
+        { $sort: { receivedAt: -1, fetchedAt: -1 } },
         {
           $group: {
             _id: '$email',
             email: { $first: '$email' },
             code: { $first: '$code' },
+            receivedAt: { $first: '$receivedAt' },
             fetchedAt: { $first: '$fetchedAt' }
           }
         },
-        { $sort: { fetchedAt: -1 } },
+        { $sort: { receivedAt: -1, fetchedAt: -1 } },
         { $limit: limit }
       ])
       .toArray();

--- a/utils/emailUtils.js
+++ b/utils/emailUtils.js
@@ -170,7 +170,8 @@ async function fetchImapCodes(db, email, limit = 5) {
                 const rec = {
                   code: m[1],
                   email: emailAddr || 'unknown',
-                  fetchedAt: new Date()
+                  fetchedAt: new Date(),
+                  receivedAt: parsed.date || new Date()
                 };
                 await db.collection('codes').insertOne(rec).catch(() => { });
                 records.push(rec);

--- a/views/codes.ejs
+++ b/views/codes.ejs
@@ -121,7 +121,10 @@
         <% if (codes && codes.length > 0) { %>
             <% codes
                 .slice()
-                .sort((a, b) => new Date(b.fetchedAt) - new Date(a.fetchedAt))
+                .sort((a, b) =>
+                    new Date(b.receivedAt || b.fetchedAt) -
+                    new Date(a.receivedAt || a.fetchedAt)
+                )
                 .forEach(function(code, index) { %>
                 <div class="col-lg-4 col-md-6">
                     <div class="code-card">


### PR DESCRIPTION
## Summary
- add bullet about email ordering to README
- store email receivedAt date when fetching codes
- order codes by receivedAt on the server
- sort by receivedAt in the view

## Testing
- `npm install --silent` *(fails: Error setting up local MongoDB)*

------
https://chatgpt.com/codex/tasks/task_e_685649a9113c83238f5344e3ea1998ed